### PR TITLE
Fixed Undefined array key "ip"

### DIFF
--- a/src/Contao/PiwikTrackingTag.php
+++ b/src/Contao/PiwikTrackingTag.php
@@ -199,7 +199,7 @@ class PiwikTrackingTag extends \Backend
         foreach ($arrIPBlacklist as $key => $value)
         {
             // Check if we have an empty value
-            if(strlen( $value["ip"]) == 0)
+            if(!isset($value["ip"]) || strlen( $value["ip"]) == 0)
             {
                 continue;
             }


### PR DESCRIPTION
Warning: Undefined array key "ip" {"exception":"[object] (ErrorException(code: 0): Warning: Undefined array key \"ip\" at /contao-4.x/vendor/menatwork/contao-matomotrackingtag-bundle/src/Contao/PiwikTrackingTag.php:202)"}